### PR TITLE
Add wait period for the new rest server

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -162,6 +162,13 @@ func (c *Controller) SwitchPortToBackup() (err error) {
 	c.BackupListen = addr + ":" + strconv.Itoa(BackupListenPort)
 
 	client = NewControllerClient("http://" + c.BackupListen)
+	for i := 0; i < SwitchWaitCount; i++ {
+		if err := client.TestConnection(); err == nil {
+			break
+		}
+		logrus.Infof("launcher: wait for controller to switch to %v", c.BackupListen)
+		time.Sleep(SwitchWaitInterval)
+	}
 	if err := client.TestConnection(); err != nil {
 		return errors.Wrapf(err, "test connection to %v failed", c.BackupListen)
 	}
@@ -187,6 +194,13 @@ func (c *Controller) SwitchPortToOriginal() (err error) {
 	}
 
 	client = NewControllerClient("http://" + c.Listen)
+	for i := 0; i < SwitchWaitCount; i++ {
+		if err := client.TestConnection(); err == nil {
+			break
+		}
+		logrus.Infof("launcher: wait for controller to switch to %v", c.Listen)
+		time.Sleep(SwitchWaitInterval)
+	}
 	if err := client.TestConnection(); err != nil {
 		return errors.Wrapf(err, "test connection to %v failed", c.Listen)
 	}

--- a/launcher.go
+++ b/launcher.go
@@ -28,6 +28,9 @@ const (
 
 	WaitInterval = time.Second
 	WaitCount    = 60
+
+	SwitchWaitInterval = time.Second
+	SwitchWaitCount    = 15
 )
 
 type Launcher struct {


### PR DESCRIPTION
We may hit `connection refused` if we connect too soon.